### PR TITLE
Fixed issue with skipping blank space in second column for color/CMC sorting

### DIFF
--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -165,10 +165,10 @@ function sortDecklist(deck, sortorder) {
 
 		}
 	
-		// We must clear out the 32nd entry, if it's blank, as it's at the top of the 2nd row
+		// We must clear out the 32nd entry, if it's blank, as it's at the top of the 2nd column
 		if (deck.length > 31) {
-			if (deck[32][1] == 0) {
-				deck.splice(32, 1);
+			if (deck[31][1] == 0) {
+				deck.splice(31, 1);
 			}
 		}
 	}
@@ -225,10 +225,10 @@ function sortDecklist(deck, sortorder) {
 
 		}
 	
-		// We must clear out the 32nd entry, if it's blank, as it's at the top of the 2nd row
+		// We must clear out the 32nd entry, if it's blank, as it's at the top of the 2nd column
 		if (deck.length > 31) {
-			if (deck[32][1] == 0) {
-				deck.splice(32, 1);
+			if (deck[31][1] == 0) {
+				deck.splice(31, 1);
 			}
 		}
 	}


### PR DESCRIPTION
At lines 169 and 229, the code attempts to shift cards up to fill what would otherwise be odd and unnecessary blank space.

The issue is that it doesn't take into account the fact that arrays are zero-indexed, so it actually will cause errors for decks that end up having exactly 32 lines taken up, because it attempts to access the 33rd index with `if (deck[32][1] == 0) {`. As such, the fix was fairly simple:

Change all (both; for CMC and color sorting) instances of the 33rd index to the 32nd index.

The new code reads as such:

```
if (deck.length > 31) {
    if (deck[31][1] == 0) {
        deck.splice(31, 1);
    }
}
```

**Test cases:**
- Sorting [this decklist](https://deckbox.org/sets/619539) using Color sorting.
- Sorting [this decklist](https://gist.github.com/Nightfirecat/34b38315543fca386c21) using CMC sorting.

Both of the above work properly after this fix.
