### PR TITLE
add unicode support; fixes marumari/decklist#2, fixes marumari/decklist#19

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 	<!-- jsPDF and associated libraries -->
 	<script type="text/javascript" src="js/jsPDF-master/jspdf.js"></script>
 	<script type="text/javascript" src="js/jsPDF-master/jspdf.plugin.addimage.js"></script>
+	<script type="text/javascript" src="js/jsPDF-master/jspdf.plugin.standard_fonts_metrics.js"></script>
 	<script type="text/javascript" src="js/FileSaver.js-master/FileSaver.js"></script>
 
 	<!-- Code for the website -->


### PR DESCRIPTION
Loading the jspdf.plugin.standard_fonts_metrics.js library adds support for unicode characters.

### Test data, output

After opening the site, run the following in console to get (as far as I'm aware) a list of every card with a unicode character (with the exception of [Ææ])

```
unicode = new Array();
for (card in cards){
  if(cards[card]["n"].match(/[àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåœ]/)){
    unicode.push(cards[card]["n"]);
  }
}
for (n in unicode) {
console.log(unicode[n]);
}
```
Once that's done, the output can be fairly easily transformed to [the following input](http://nightfirecat.github.io/decklist/?deckmain=1%20Chicken%20%C3%A0%20la%20King%0A1%20Lim-D%C3%BBl%27s%20High%20Guard%0A1%20Oath%20of%20Lim-D%C3%BBl%0A1%20Ifh-B%C3%ADff%20Efreet%0A1%20S%C3%A9ance%0A1%20Lim-D%C3%BBl%27s%20Hex%0A1%20Lim-D%C3%BBl%27s%20Cohort%0A1%20Lim-D%C3%BBl%27s%20Paladin%0A1%20J%C3%B6tun%20Grunt%0A1%20Lim-D%C3%BBl%27s%20Vault%0A1%20Saut%C3%A9%0A1%20D%C3%A9j%C3%A0%20Vu%0A1%20El-Hajj%C3%A2j%0A1%20J%C3%B6tun%20Owl%20Keeper%0A1%20Juz%C3%A1m%20Djinn%0A1%20Legions%20of%20Lim-D%C3%BBl%0A1%20Ghazb%C3%A1n%20Ogre%0A1%20Lim-D%C3%BBl%20the%20Necromancer%0A1%20Dand%C3%A2n%0A1%20Ghazb%C3%A1n%20Ogress%0A1%20Khab%C3%A1l%20Ghoul%0A1%20M%C3%A1rton%20Stromgald%0A1%20B%C3%B6sium%20Strip%0A1%20Jun%C3%BAn%20Efreet%0A1%20Ring%20of%20Ma%27r%C3%BBf). As shown, the characters render correctly.