### PR TITLE
Better 'ae' detection when checking a card's name against DB

### DIFF
--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -115,8 +115,9 @@ function parseDecklist() {
   // appropriate list (main or side), otherwise add it to the unrecognized map.
   function recognizeCard(card, quantity, list) {
     list = list || 'main';
+    var aeloc = card.toLowerCase().indexOf('ae');
 
-    if (card.slice(0,2).toLowerCase() === 'ae') { recognized = objectHasPropertyCI(cards, '\u00e6'+card.slice(2)); }
+    if (aeloc != -1) { recognized = objectHasPropertyCI(cards, card.slice(0,aeloc)+'\u00e6'+card.slice(aeloc+2)); }
     else { recognized = objectHasPropertyCI(cards, card); }
 
     // Always add the card to the list, regardless of if the card is recognized


### PR DESCRIPTION
A friend of mine discovered that this website does not recognize [Unravel the Aether](http://magiccards.info/query?q=unravel%20the%20aether).

It turns out that the website does not properly recognize a card if its name contains AE but does not start with AE (ex. Anchor to the Aether...).

So made a hackish fix that does not look pretty but gets the job done **until WotC prints a card that has two AEs in the name**.

This is how it is now:
![Before](https://cloud.githubusercontent.com/assets/2484055/9995507/424998b8-60bd-11e5-9cd0-b29775a04be8.png)

...and this is how it will be:
![After](https://cloud.githubusercontent.com/assets/2484055/9995508/43ef70ca-60bd-11e5-98eb-1542ac00d815.png)

PS. Personally, I think it would be better to change all the unicode 'AE's into ascii 'AE's when parsing the JSON file in the first place, but I could not get parsecards.py to work on my computer.