### PR TITLE
Allow any number of Wastes in decks

### DIFF
--- a/js/decklist/main.js
+++ b/js/decklist/main.js
@@ -449,7 +449,7 @@ function validateInput() {
   excessCards = [];
   allowedDupes = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest',
     'Snow-Covered Plains', 'Snow-Covered Island', 'Snow-Covered Swamp', 'Snow-Covered Mountain',
-    'Snow-Covered Forest', 'Relentless Rats', 'Shadowborn Apostle'];
+    'Snow-Covered Forest', 'Wastes', 'Relentless Rats', 'Shadowborn Apostle'];
   for (i = 0; i < mainPlusSide.length; i++) {
     if (parseInt(mainPlusSide[i][1]) > 4) {
       allowed = false;


### PR DESCRIPTION
Wastes are basic lands, so decks can run any number of them.