### PR TITLE
Sort by type

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
           <input type="radio" id="sortorder3" name="sortorder" checked><label for="sortorder3">Color (recommended)</label>
           <input type="radio" id="sortorder4" name="sortorder"><label for="sortorder4">Numerically</label>
           <input type="radio" id="sortorder5" name="sortorder"><label for="sortorder5">Original</label>
+          <input type="radio" id="sortorder6" name="sortorder"><label for="sortorder6">Type</label>
         </div>
       </div>
     </div>

--- a/js/cards/parsecards.py
+++ b/js/cards/parsecards.py
@@ -73,11 +73,11 @@ for card in cards:
     elif cards[card]['colors'] == ['Red']:    ocards[ocard]['c'] = 'D'
     elif cards[card]['colors'] == ['Green']:  ocards[ocard]['c'] = 'E'
 
-    if   'Land'     in cards[card]['types']: ocards[ocard]['t'] = '1'
-    elif 'Creature' in cards[card]['types']: ocards[ocard]['t'] = '2'
-    elif 'Sorcery'  in cards[card]['types']: ocards[ocard]['t'] = '3'
-    elif 'Instant'  in cards[card]['types']: ocards[ocard]['t'] = '3'
-    else:                                    ocards[ocard]['t'] = '4'
+    if   'Land'     in cards[card]['types']:  ocards[ocard]['t'] = '1'
+    elif 'Creature' in cards[card]['types']:  ocards[ocard]['t'] = '2'
+    elif 'Sorcery'  in cards[card]['types']:  ocards[ocard]['t'] = '3'
+    elif 'Instant'  in cards[card]['types']:  ocards[ocard]['t'] = '3'
+    else:                                     ocards[ocard]['t'] = '4'
 
     # Now try to deal with CMC
     if 'cmc' not in cards[card]: ocards[ocard]['m'] = 99

--- a/js/cards/parsecards.py
+++ b/js/cards/parsecards.py
@@ -7,6 +7,7 @@ import json
 # c (color) = White = A, Blue = B, Black = C, Red = D, Green = E, Gold = F, Artifact = G , Split = S, Unknown = X, Land = Z
 # m (CMC) = N  (Split = 98, Land = 99)
 # n (actual name) = 'true name nemesis' to 'True Name Nemesis'
+# t (type) = 1 = land, 2 = creature, 3 = instant or sorcery 4 = other
 
 FORMATS = ('Standard', 'Modern', 'Legacy')
 
@@ -71,6 +72,12 @@ for card in cards:
     elif cards[card]['colors'] == ['Black']:  ocards[ocard]['c'] = 'C'
     elif cards[card]['colors'] == ['Red']:    ocards[ocard]['c'] = 'D'
     elif cards[card]['colors'] == ['Green']:  ocards[ocard]['c'] = 'E'
+
+    if   'Land'     in cards[card]['types']: ocards[ocard]['t'] = '1'
+    elif 'Creature' in cards[card]['types']: ocards[ocard]['t'] = '2'
+    elif 'Sorcery'  in cards[card]['types']: ocards[ocard]['t'] = '3'
+    elif 'Instant'  in cards[card]['types']: ocards[ocard]['t'] = '3'
+    else:                                    ocards[ocard]['t'] = '4'
 
     # Now try to deal with CMC
     if 'cmc' not in cards[card]: ocards[ocard]['m'] = 99

--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -110,6 +110,10 @@ function parseDecklist() {
     maindeck = sortDecklist(maindeck, 'numerically');
     sideboard = sortDecklist(sideboard, 'alphabetically');
   }
+  else if ( $('#sortorderfloat input[name=sortorder]:checked').prop('id') == 'sortorder6' ) { // type
+    maindeck = sortDecklist(maindeck, 'type');
+    sideboard = sortDecklist(sideboard, 'alphabetically');
+  }
 
   // Check the card name against the card database. If it exists, add it to the
   // appropriate list (main or side), otherwise add it to the unrecognized map.
@@ -301,6 +305,56 @@ function sortDecklist(deck, sortorder) {
 
     // After sorting is done, we can remove the lower case index
     for (i = 0; i < deck.length; i++) { deck[i] = [ deck[i][2], deck[i][0] ] }
+  }
+
+  else if ( sortorder == 'type' ) {
+
+    var type_to_cards = {}
+
+    for (i = 0; i < deck.length; i++) {
+
+      // We're going to search by lower case
+      var lcard = deck[i][0].toLowerCase();
+
+      // Grab the card's type
+      if (lcard in cards) { type = cards[ lcard ]['t']; }
+      else { type = 'z'; } // Unknown
+
+      // Create the type subarray
+      if ( !(type in type_to_cards ) ) { type_to_cards[type] = []; }
+
+      // Fix the Aetherling issue until the PDF things supports it
+      lcard = lcard.replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
+      deck[i][0] = deck[i][0].replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
+
+      // Add the card to that array, including lower-case (only used for sorting)
+      type_to_cards[type].push( [ lcard, deck[i][0], deck[i][1] ] );
+
+    }
+
+    // Get the list of types in the deck
+    type_to_cards_keys = Object.keys(type_to_cards).sort();
+
+    // Sort each CMC, then append them to the final array
+    deck = []
+    for (i = 0; i < type_to_cards_keys.length; i++) {
+      // Push a blank entry onto deck (to separate types)
+      // unless the deck is empty
+      if (deck.length !== 0) {
+        deck.push(['', 0]);
+      }
+
+      type = type_to_cards_keys[i];
+
+      type_to_cards[ type ].sort();   // type_to_cards[3]
+
+      for (j = 0; j < type_to_cards[type].length; j++) {
+        card = type_to_cards[type][j][1];
+        quantity = type_to_cards[type][j][2];
+
+        deck.push([card, quantity]);
+      }
+    }
   }
 
   // Get the card's true English name (ignoring any particular capitalization that someone may have done)

--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -346,7 +346,7 @@ function sortDecklist(deck, sortorder) {
 
       type = type_to_cards_keys[i];
 
-      type_to_cards[ type ].sort();   // type_to_cards[3]
+      type_to_cards[ type ].sort();
 
       for (j = 0; j < type_to_cards[type].length; j++) {
         card = type_to_cards[type][j][1];


### PR DESCRIPTION
Add sorting/grouping by type, similar to how the deck lists on mtgtop8.com are organized:

1. Lands
1. Creatures
1. Spells
1. Other

Preference of group membership descending in that order, i.e. Dryad Arbor is with the other lands, not creatures.

Actual code changes in the first commit, update to the generated cards list JS file in the second in case that's undesired.

JS code change is a giant copy and paste / search and replace of the CMC sort variant.