### PR TITLE
link update

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
     </div>
 
     <div class="footer">
-      Magic: the Gathering Decklist Generator by <a href="https://pokeinthe.io/">April King</a>. Please send feedback to <a href="mailto:april@pokeinthe.io?subject=Decklist.org%20feedback">april@pokeinthe.io</a>, or contribute issue reports or code additions <a href="https://github.com/marumari/decklist">via GitHub</a>.<br />Please read the <a href="html/directlinking.html">direct linking</a> instructions, on how to link directly to decklist.org from your website.<br /><br />Magic: The Gathering &reg; Wizards of the Coast.
+      Magic: the Gathering Decklist Generator by <a href="https://pokeinthe.io/">April King</a>. Please send feedback to <a href="mailto:april@pokeinthe.io?subject=Decklist.org%20feedback">april@pokeinthe.io</a>, or contribute issue reports or code additions <a href="https://github.com/april/decklist">via GitHub</a>.<br />Please read the <a href="html/directlinking.html">direct linking</a> instructions, on how to link directly to decklist.org from your website.<br /><br />Magic: The Gathering &reg; Wizards of the Coast.
     </div>
   </div>
 </body>


### PR DESCRIPTION
tiny update: instead the former repo name, link to the current one directly to reduce confusion

old repo: "https://github.com/marumari/decklist"
new repo: "https://github.com/april/decklist"