### PR TITLE
Clean up generatecards.sh

### DIFF
--- a/js/cards/generatecards.sh
+++ b/js/cards/generatecards.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+set -e
+
 # Clean up a bit
-rm -f *.js *.zip
+rm -f -- *.js *.zip
 
 curl http://mtgjson.com/json/AllCards-x.json.zip > AllCards-x.json.zip
 unzip AllCards-x.json.zip
@@ -10,8 +12,7 @@ unzip AllCards-x.json.zip
 ./parsecards.py
 
 # Minify
-java -jar ../../tools/yuicompressor-2.4.8.jar -o '.js$:-min.js' *.js
+java -jar ../../tools/yuicompressor-2.4.8.jar -o '.js$:-min.js' -- *.js
 
 # Clean up a bit
-rm AllCards*
-rm decklist-cards.js
+rm AllCards* decklist-cards.js


### PR DESCRIPTION
`set -e` will stop execution if errors are encountered. (For instance,
if the script is run on a Windows environment, `/usr/bin/env python3`
may not be set and will cause the Python script call to fail)

File descriptors starting with a glob, such as `*.js` are changed to be
preceded with `--` to ensure strangely-named files are not improperly
interpreted as flags.