### PR TITLE
Group split cards with instants and soceries

### DIFF
--- a/js/cards/parsecards.py
+++ b/js/cards/parsecards.py
@@ -99,6 +99,7 @@ for card in cards:
         ocards[ocard]['c'] = 'S'
         ocards[ocard]['m'] = 98 
         ocards[ocard]['n'] = name
+        ocards[ocard]['t'] = '3'
 
         legality = getLegalities(card, cards)
         if legality != "": ocards[ocard]['b'] = legality


### PR DESCRIPTION
Currently, split cards written with both halves (Fire // Ice as opposed to Fire) have no type value, and are grouped separately from all other types. As all split cards are currently in the set of instants and socrceries, group them with those instead.