### PR TITLE
Create GitHub Action to run generatecards.sh nightly, and commit new minified card list if it's been updated

### DIFF
--- a/.github/workflows/generate-cards.yml
+++ b/.github/workflows/generate-cards.yml
@@ -1,0 +1,19 @@
+name: Generate Cards
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  generate-cards:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install terser
+        run: npm i terser -g
+      - name: Run shell script
+        run: ./generatecards.sh
+        working-directory: ./js/cards/
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update card list


### PR DESCRIPTION
Rather than April having to manually run `generatecards.sh` whenever a new set comes out, this PR adds a GitHub Action that will run the shell script nightly, and if the minified card list is different than what's currently checked in, it'll check it in (which will trigger the GitHub Pages action and deploy).

I've had it running successfully on my downstream repo (see https://github.com/richardneal/decklist/actions for the Actions history).